### PR TITLE
fix the path to LICENSE in artifacts.rs

### DIFF
--- a/src/release/artifacts.rs
+++ b/src/release/artifacts.rs
@@ -1477,7 +1477,7 @@ Released on: {}
 fn generate_license(&self, license_type: &str, format: &DocumentationFormat, output_path: &PathBuf) -> Result<Artifact, SemanticError> {
         println!("Generating license file for: {}", license_type);
 
-        let license_content = include_str!("../../../../LICENSE");
+        let license_content = include_str!("../../LICENSE");
 
         std::fs::write(output_path, license_content.as_bytes()).map_err(|e| SemanticError::Internal {
             message: format!("Failed to write license: {}", e),


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/aether/issues/12.

This fixes the error about artifacts.rs pointing to the wrong path:

```
error: couldn't read `src/release/../../../../LICENSE`: No such file or directory (os error 2)
    --> src/release/artifacts.rs:1480:31
     |
1480 |         let license_content = include_str!("../../../../LICENSE");
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this error originates in the macro `include_str` (in Nightly builds, run with -Z macro-backtrace for more info)
help: there is a file with the same name in a different directory
     |
1480 |         let license_content = include_str!("../../LICENSE");
     |                                            ~~~~~~~~~~~~~~~

```